### PR TITLE
[patch:lib] Upgrade minimum torch version to v1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ pip install torchfsdd
 
 **Note**: TorchFSDD assumes you have the following packages already installed (along with Python v3.6+).
 
-- [`torch`](https://github.com/pytorch/audio) (>= 1.6.0)
-- [`torchaudio`](https://github.com/pytorch/pytorch) (>= 0.6.0)
+- [`torch`](https://github.com/pytorch/audio) (>= 1.8.0)
+- [`torchaudio`](https://github.com/pytorch/pytorch) (>= 0.8.0)
 
 Since there are many different possible configurations when installing PyTorch (e.g. CPU or GPU, CUDA version), we leave this up to the user instead of specifying particular binaries to install alongside TorchFSDD.
 

--- a/lib/test/requirements.txt
+++ b/lib/test/requirements.txt
@@ -1,8 +1,5 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.6.0+cpu; sys_platform == 'linux'
-torch==1.6.0; sys_platform == 'darwin'
-torchaudio==0.6.0+cpu; sys_platform == 'linux'
-torchaudio==0.6.0; sys_platform == 'darwin'
-torchvision==0.7.0+cpu; sys_platform == 'linux'
-torchvision==0.7.0; sys_platform == 'darwin'
+torch==1.8.0
+torchaudio==0.8.0
+torchvision==0.9.0
 pytest==6.2.3

--- a/lib/torchfsdd/__init__.py
+++ b/lib/torchfsdd/__init__.py
@@ -7,8 +7,8 @@ if packaging.version.parse(platform.python_version()) < packaging.version.parse(
 else:
     from importlib import metadata
 
-MIN_TORCH_VERSION = '1.6'
-MIN_TORCHAUDIO_VERSION = '0.6'
+MIN_TORCH_VERSION = '1.8'
+MIN_TORCHAUDIO_VERSION = '0.8'
 
 def check_package(pkg, min_version, url):
     """Checks whether a specified package has been installed,
@@ -20,7 +20,7 @@ def check_package(pkg, min_version, url):
         Name of the package.
 
     min_version: str
-        Minimum version for the package, e.g. `1.6`.
+        Minimum version for the package, e.g. `1.8`.
 
     url: str
         Package installation page URL (for help).

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,10 +1,10 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
-torch==1.6.0+cpu; sys_platform == 'linux'
-torch==1.6.0; sys_platform == 'darwin'
-torchaudio==0.6.0+cpu; sys_platform == 'linux'
-torchaudio==0.6.0; sys_platform == 'darwin'
-torchvision==0.7.0+cpu; sys_platform == 'linux'
-torchvision==0.7.0; sys_platform == 'darwin'
+torch==1.8.0+cpu; sys_platform == 'linux'
+torch==1.8.0; sys_platform == 'darwin'
+torchaudio==0.8.0+cpu; sys_platform == 'linux'
+torchaudio==0.8.0; sys_platform == 'darwin'
+torchvision==0.9.0+cpu; sys_platform == 'linux'
+torchvision==0.9.0; sys_platform == 'darwin'
 jupyter
 matplotlib
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
     ],
     python_requires = '>=3.6',
     install_requires = install_requires,
-    extra_requires = {'torch': ['torch>=1.6+cpu', 'torchaudio>=0.6+cpu']}
+    extra_requires = {'torch': ['torch>=1.8+cpu', 'torchaudio>=0.8+cpu']}
 )


### PR DESCRIPTION
- Upgrade minimum package dependency versions:
  - `torch` (>= 1.8)
  - `torchaudio` (>= 0.8)
  - `torchvision` (>= 0.9) - only used in tests and notebooks