### PR TITLE
[patch:pkg] Change extra_requires to extras_require in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
     ],
     python_requires = '>=3.6',
     install_requires = install_requires,
-    extra_requires = {'torch': ['torch>=1.8+cpu', 'torchaudio>=0.8+cpu']}
+    extras_require = {'torch': ['torch>=1.8+cpu', 'torchaudio>=0.8+cpu']}
 )


### PR DESCRIPTION
- Change `extra_requires` to `extras_require` in `setup.py`.<br/>(this is why `pip install torchfsdd[torch]` didn't work!)